### PR TITLE
Refactored internal handling of mod file paths

### DIFF
--- a/server/Oraide.Core/Entities/MemberLocation.cs
+++ b/server/Oraide.Core/Entities/MemberLocation.cs
@@ -1,20 +1,30 @@
-﻿namespace Oraide.Core.Entities
+﻿using System;
+using System.IO;
+
+namespace Oraide.Core.Entities
 {
 	public readonly struct MemberLocation
 	{
-		public readonly string FilePath;
+		public readonly Uri FileUri;
 
 		public readonly int LineNumber;
 
 		public readonly int CharacterPosition;
 
-		public MemberLocation(string filePath, int lineNumber, int characterPosition)
+		public MemberLocation(string fileUriString, int lineNumber, int characterPosition)
 		{
-			FilePath = filePath;
+			FileUri = File.Exists(fileUriString) || Uri.IsWellFormedUriString(fileUriString, UriKind.Absolute) ? new Uri(fileUriString) : null;
 			LineNumber = lineNumber;
 			CharacterPosition = characterPosition;
 		}
 
-		public override string ToString() => $"{FilePath ?? "<empty>"}:{LineNumber},{CharacterPosition}";
+		public MemberLocation(Uri fileUri, int lineNumber, int characterPosition)
+		{
+			FileUri = fileUri;
+			LineNumber = lineNumber;
+			CharacterPosition = characterPosition;
+		}
+
+		public override string ToString() => $"{FileUri?.AbsolutePath ?? "<empty>"}:{LineNumber},{CharacterPosition}";
 	}
 }

--- a/server/Oraide.Core/OpenRaFolderUtils.cs
+++ b/server/Oraide.Core/OpenRaFolderUtils.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -94,7 +95,7 @@ namespace Oraide.Core
 			return fileFullPath;
 		}
 
-		public static string ResolveFilePath(string fileReference, IReadOnlyDictionary<string, string> mods)
+		public static Uri ResolveFilePath(string fileReference, IReadOnlyDictionary<string, string> mods)
 		{
 			string fileFullPath = null;
 			if (!string.IsNullOrWhiteSpace(fileReference))
@@ -106,7 +107,15 @@ namespace Oraide.Core
 					fileFullPath = Path.Combine(mods[modId], filePath);
 			}
 
-			return fileFullPath;
+			return fileFullPath == null ? null : new Uri(fileFullPath);
+		}
+
+		public static string NormalizeFileUriString(string fileUriString)
+		{
+			// HACK HACK HACK!!!
+			// For whatever reason we receive the file URI borked - looks to be encoded for JSON, but the deserialization doesn't fix it.
+			// No idea if this is an issue with VSCode or the LSP library used as there are currently no clients for other text editors.
+			return fileUriString.Replace("%3A", ":");
 		}
 	}
 }

--- a/server/Oraide.LanguageServer/Caching/OpenFileCache.cs
+++ b/server/Oraide.LanguageServer/Caching/OpenFileCache.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
+using Oraide.Core;
 using Oraide.Core.Entities.MiniYaml;
 using Oraide.MiniYaml;
 
@@ -26,31 +27,35 @@ namespace Oraide.LanguageServer.Caching
 			ReadOnlyCollection<string> Lines)
 			this[string filePath] => openFiles[filePath];
 
-		public void AddOrUpdateOpenFile(string fileUri)
+		public void AddOrUpdateOpenFile(string fileUriString)
 		{
-			var filePath = fileUri.Replace("file:///", string.Empty).Replace("%3A", ":");
+			var uriString = OpenRaFolderUtils.NormalizeFileUriString(fileUriString);
+			var filePath = new Uri(uriString).AbsolutePath;
 			var text = File.ReadAllText(filePath);
-			AddOrUpdateOpenFile(fileUri, text);
+			AddOrUpdateOpenFile(uriString, text);
 		}
 
-		public void AddOrUpdateOpenFile(string fileUri, string content)
+		public void AddOrUpdateOpenFile(string fileUriString, string content)
 		{
+			var uriString = OpenRaFolderUtils.NormalizeFileUriString(fileUriString);
 			var lines = content.Split(new[] {"\r\n", "\n"}, StringSplitOptions.None);
-			var nodes = yamlInformationProvider.ParseText(content);
-			openFiles[fileUri] = (
+			var nodes = yamlInformationProvider.ParseText(content, uriString);
+			openFiles[uriString] = (
 				new ReadOnlyCollection<YamlNode>(nodes.Original.ToArray()),
 				new ReadOnlyCollection<YamlNode>(nodes.Flattened.ToArray()),
 				new ReadOnlyCollection<string>(lines));
 		}
 
-		public void RemoveOpenFile(string filePath)
+		public void RemoveOpenFile(string fileUriString)
 		{
-			openFiles.Remove(filePath);
+			var uriString = OpenRaFolderUtils.NormalizeFileUriString(fileUriString);
+			openFiles.Remove(uriString);
 		}
 
-		public bool ContainsFile(string filePath)
+		public bool ContainsFile(string fileUriString)
 		{
-			return openFiles.ContainsKey(filePath);
+			var uriString = OpenRaFolderUtils.NormalizeFileUriString(fileUriString);
+			return openFiles.ContainsKey(uriString);
 		}
 	}
 }

--- a/server/Oraide.LanguageServer/Caching/SymbolCache.cs
+++ b/server/Oraide.LanguageServer/Caching/SymbolCache.cs
@@ -85,7 +85,7 @@ namespace Oraide.LanguageServer.Caching
 				var modSymbols = new ModSymbols(actorDefinitions, weaponDefinitions, conditionDefinitions, cursorDefinitions, paletteDefinitions);
 
 				var mapsDir = OpenRaFolderUtils.ResolveFilePath(modManifest.MapsFolder, mods);
-				var allMaps = mapsDir == null ? Enumerable.Empty<string>() : Directory.EnumerateDirectories(mapsDir);
+				var allMaps = mapsDir == null ? Enumerable.Empty<string>() : Directory.EnumerateDirectories(mapsDir.AbsolutePath);
 				var mapDirs = allMaps.Where(x => File.Exists(Path.Combine(x, "map.yaml")) && File.Exists(Path.Combine(x, "map.bin"))).ToArray();
 				var maps = mapDirs.Select(x => new MapManifest(x, yamlInformationProvider.ReadMapFile(x), modManifest.MapsFolder));
 

--- a/server/Oraide.LanguageServer/Extensions/LspTypesExtensions.cs
+++ b/server/Oraide.LanguageServer/Extensions/LspTypesExtensions.cs
@@ -32,7 +32,7 @@ namespace Oraide.LanguageServer.Extensions
 		{
 			return new Location
 			{
-				Uri = new Uri(memberLocation.FilePath).ToString(),
+				Uri = memberLocation.FileUri.AbsoluteUri,
 				Range = memberLocation.ToRange(length)
 			};
 		}

--- a/server/Oraide.LanguageServer/LanguageServerProtocolHandlers/TextDocument/TextDocumentColorHandler.cs
+++ b/server/Oraide.LanguageServer/LanguageServerProtocolHandlers/TextDocument/TextDocumentColorHandler.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
 using LspTypes;
+using Oraide.Core;
 using Oraide.LanguageServer.Abstractions.LanguageServerProtocolHandlers;
 using Oraide.LanguageServer.Caching;
 
@@ -26,8 +27,13 @@ namespace Oraide.LanguageServer.LanguageServerProtocolHandlers.TextDocument
 					if (trace)
 						Console.Error.WriteLine("<-- TextDocument-DocumentColor");
 
+					// HACK HACK HACK!!!
+					// For whatever reason we receive the file URI borked - looks to be encoded for JSON, but the deserialization doesn't fix it.
+					// No idea if this is an issue with VSCode or the LSP library used as there are currently no clients for other text editors.
+					var incomingFileUriString = OpenRaFolderUtils.NormalizeFileUriString(request.TextDocument.Uri);
+
 					var results = new List<ColorInformation>();
-					var (yamlNodes, flattenedYamlNodes, lines) = openFileCache[request.TextDocument.Uri];
+					var (yamlNodes, flattenedYamlNodes, lines) = openFileCache[incomingFileUriString];
 					foreach (var node in flattenedYamlNodes)
 					{
 						if (node.Key == null || node.ChildNodes != null)

--- a/server/Oraide.LanguageServer/LanguageServerProtocolHandlers/TextDocument/TextDocumentDefinitionHandler.cs
+++ b/server/Oraide.LanguageServer/LanguageServerProtocolHandlers/TextDocument/TextDocumentDefinitionHandler.cs
@@ -306,48 +306,35 @@ namespace Oraide.LanguageServer.LanguageServerProtocolHandlers.TextDocument
 			{
 				case 0:
 				{
+					string filePath = null;
 					if (cursorTarget.TargetNode.Key is "Rules" or "Sequences" or "ModelSequences" or "Weapons" or "Voices" or "Music" or "Notifications")
 					{
 						if (cursorTarget.TargetString.Contains('|'))
 						{
-							var resolvedFile = OpenRaFolderUtils.ResolveFilePath(cursorTarget.TargetString, (cursorTarget.ModId, symbolCache[cursorTarget.ModId].ModFolder));
-							if (File.Exists(resolvedFile))
-							{
-								return new[]
-								{
-									new Location
-									{
-										Uri = new Uri(resolvedFile).ToString(),
-										Range = new LspTypes.Range
-										{
-											Start = new Position(0, 0),
-											End = new Position(0, 0)
-										}
-									}
-								};
-							}
+							filePath = OpenRaFolderUtils.ResolveFilePath(cursorTarget.TargetString, (cursorTarget.ModId, symbolCache[cursorTarget.ModId].ModFolder));
 						}
 						else
 						{
-							var targetPath = cursorTarget.TargetStart.FilePath.Replace("file:///", string.Empty).Replace("%3A", ":");
+							var targetPath = cursorTarget.TargetStart.FileUri.AbsolutePath;
 							var mapFolder = Path.GetDirectoryName(targetPath);
-							var filePath = Path.Combine(mapFolder, cursorTarget.TargetString);
-							if (File.Exists(filePath))
-							{
-								return new[]
-								{
-									new Location
-									{
-										Uri = new Uri(filePath).ToString(),
-										Range = new LspTypes.Range
-										{
-											Start = new Position(0, 0),
-											End = new Position(0, 0)
-										}
-									}
-								};
-							}
+							filePath = Path.Combine(mapFolder, cursorTarget.TargetString);
 						}
+					}
+
+					if (filePath != null && File.Exists(filePath))
+					{
+						return new[]
+						{
+							new Location
+							{
+								Uri = new Uri(filePath).ToString(),
+								Range = new LspTypes.Range
+								{
+									Start = new Position(0, 0),
+									End = new Position(0, 0)
+								}
+							}
+						};
 					}
 
 					return null;

--- a/server/Oraide.LanguageServer/LanguageServerProtocolHandlers/TextDocument/TextDocumentHoverHandler.cs
+++ b/server/Oraide.LanguageServer/LanguageServerProtocolHandlers/TextDocument/TextDocumentHoverHandler.cs
@@ -439,7 +439,7 @@ namespace Oraide.LanguageServer.LanguageServerProtocolHandlers.TextDocument
 						}
 						else
 						{
-							var targetPath = cursorTarget.TargetStart.FilePath.Replace("file:///", string.Empty).Replace("%3A", ":");
+							var targetPath = cursorTarget.TargetStart.FileUri.AbsolutePath.Replace("file:///", string.Empty).Replace("%3A", ":");
 							var mapFolder = Path.GetDirectoryName(targetPath);
 							var mapName = Path.GetFileName(mapFolder);
 							var filePath = Path.Combine(mapFolder, cursorTarget.TargetString);

--- a/server/Oraide.LanguageServer/LanguageServerProtocolHandlers/Workspace/DidChangeWatchedFilesHandler.cs
+++ b/server/Oraide.LanguageServer/LanguageServerProtocolHandlers/Workspace/DidChangeWatchedFilesHandler.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Linq;
 using LspTypes;
+using Oraide.Core;
 using Oraide.Core.Entities.MiniYaml;
 using Oraide.LanguageServer.Abstractions.LanguageServerProtocolHandlers;
 using Oraide.LanguageServer.Caching;
@@ -29,23 +30,28 @@ namespace Oraide.LanguageServer.LanguageServerProtocolHandlers.Workspace
 
 					foreach (var requestChange in request.Changes)
 					{
+						// HACK HACK HACK!!!
+						// For whatever reason we receive the file URI borked - looks to be encoded for JSON, but the deserialization doesn't fix it.
+						// No idea if this is an issue with VSCode or the LSP library used as there are currently no clients for other text editors.
+						var incomingFileUriString = OpenRaFolderUtils.NormalizeFileUriString(requestChange.Uri);
+
 						// Check if the affected file(s) are present in the "currently opened files" cache and invalidate/update that.
-						if (openFileCache.ContainsFile(requestChange.Uri))
+						if (openFileCache.ContainsFile(incomingFileUriString))
 						{
 							if(requestChange.FileChangeType == FileChangeType.Deleted)
-								openFileCache.RemoveOpenFile(requestChange.Uri);
+								openFileCache.RemoveOpenFile(incomingFileUriString);
 							else if (requestChange.FileChangeType == FileChangeType.Changed)
-								openFileCache.AddOrUpdateOpenFile(requestChange.Uri);
+								openFileCache.AddOrUpdateOpenFile(incomingFileUriString);
 						}
 
 						// Check if this is a map-related file and potentially load the map into the symbol cache.
-						TryGetModId(requestChange.Uri, out var modId);
-						var fileUri = requestChange.Uri;
+						TryGetModId(incomingFileUriString, out var modId);
+						var fileUri = new Uri(incomingFileUriString);
 
 						var modManifest = symbolCache[modId].ModManifest;
-						var fileName = fileUri.Split($"mods/{modId}/")[1];
+						var fileName = fileUri.AbsoluteUri.Split($"mods/{modId}/")[1];
 						var fileReference = $"{modId}|{fileName}";
-						var filePath = fileUri.Replace("file:///", string.Empty).Replace("%3A", ":");
+						var filePath = fileUri.AbsolutePath;
 
 						if (!modManifest.RulesFiles.Contains(fileReference)
 						    && !modManifest.WeaponsFiles.Contains(fileReference)

--- a/server/Oraide.MiniYaml/YamlInformationProvider.cs
+++ b/server/Oraide.MiniYaml/YamlInformationProvider.cs
@@ -57,9 +57,9 @@ namespace Oraide.MiniYaml
 			return OpenRAMiniYamlParser.GetPaletteDefinitions(referencedFiles, mods, knownPaletteTypes);
 		}
 
-		public (IEnumerable<YamlNode> Original, IEnumerable<YamlNode> Flattened) ParseText(string text)
+		public (IEnumerable<YamlNode> Original, IEnumerable<YamlNode> Flattened) ParseText(string text, string fileUriString = null)
 		{
-			return OpenRAMiniYamlParser.ParseText(text);
+			return OpenRAMiniYamlParser.ParseText(text, fileUriString);
 		}
 	}
 }


### PR DESCRIPTION
Now we use `Uri`s wherever possible. This makes things cleaner by removing some manual path manipulations, consistent with both the client requests and internally and enables adding new features.