### PR TITLE
Fixed code parsing throwing on invalid type cast

### DIFF
--- a/server/Oraide.Csharp/CodeParsers/RoslynCodeParser.cs
+++ b/server/Oraide.Csharp/CodeParsers/RoslynCodeParser.cs
@@ -81,7 +81,7 @@ namespace Oraide.Csharp.CodeParsers
 										if (member is FieldDeclarationSyntax fieldMember
 										    && fieldMember.Modifiers.Any(x => x.ValueText == "static")
 										    && fieldMember.Modifiers.Any(x => x.ValueText == "readonly")
-										    && (fieldMember.Declaration.Type as GenericNameSyntax).Identifier.ValueText == "SpriteSequenceField")
+										    && (fieldMember.Declaration.Type as GenericNameSyntax)?.Identifier.ValueText == "SpriteSequenceField")
 										{
 											foreach (var fieldInfo in ParseClassField(filePath, fileText, fieldMember))
 											{


### PR DESCRIPTION
This would be the case for older versions of the code and was identified in the RA2 repo.