### PR TITLE
Changed CodeSymbols.AssetLoaders to dict of lookups

### DIFF
--- a/server/Oraide.LanguageServer/Caching/Entities/CodeSymbols.cs
+++ b/server/Oraide.LanguageServer/Caching/Entities/CodeSymbols.cs
@@ -36,7 +36,7 @@ namespace Oraide.LanguageServer.Caching.Entities
 		/// <summary>
 		/// Asset loader types grouped by asset type (Package, Sound, Sprite, Video).
 		/// </summary>
-		public IReadOnlyDictionary<string, Dictionary<string, ClassInfo>> AssetLoaders { get; }
+		public IReadOnlyDictionary<string, ILookup<string, ClassInfo>> AssetLoaders { get; }
 
 		/// <summary>
 		/// Widget type information grouped by type name.
@@ -57,7 +57,7 @@ namespace Oraide.LanguageServer.Caching.Entities
 			WeaponInfo = weaponInfo;
 			SpriteSequenceInfos = spriteSequenceInfos;
 			EnumInfos = enumInfos;
-			AssetLoaders = assetLoaders.ToDictionary(x => x.Key, y => y.ToDictionary(m => m.Name, n => n));
+			AssetLoaders = assetLoaders.ToDictionary(x => x.Key, y => y.ToLookup(m => m.Name, n => n));
 			Widgets = widgets;
 			WidgetLogicTypes = widgetLogicTypes;
 		}

--- a/server/Oraide.LanguageServer/FileHandlingServices/ModFileHandlingService.Value.Completion.cs
+++ b/server/Oraide.LanguageServer/FileHandlingServices/ModFileHandlingService.Value.Completion.cs
@@ -24,25 +24,28 @@ namespace Oraide.LanguageServer.FileHandlingServices
 			var presentValues = cursorTarget.TargetNode.Value?.Split(',').Select(x => x.Trim()) ?? Enumerable.Empty<string>();
 
 			// Asset loaders:
+
+			// Using .First() is not great but we have no way to differentiate between traits of the same name
+			// until the server learns the concept of a mod and loaded assemblies.
 			if (cursorTarget.TargetNode.Key == "PackageFormats")
-				return codeSymbols.AssetLoaders["Package"].Values
-					.Where(x => !presentValues.Contains(x.Name))
-					.Select(x => x.ToCompletionItem("Package loader"));
+				return codeSymbols.AssetLoaders["Package"]
+					.Where(x => !presentValues.Contains(x.Key))
+					.Select(x => x.First().ToCompletionItem("Package loader"));
 
 			if (cursorTarget.TargetNode.Key == "SoundFormats")
-				return codeSymbols.AssetLoaders["Sound"].Values
-					.Where(x => !presentValues.Contains(x.Name))
-					.Select(x => x.ToCompletionItem("Sound loader"));
+				return codeSymbols.AssetLoaders["Sound"]
+					.Where(x => !presentValues.Contains(x.Key))
+					.Select(x => x.First().ToCompletionItem("Sound loader"));
 
 			if (cursorTarget.TargetNode.Key == "SpriteFormats")
-				return codeSymbols.AssetLoaders["Sprite"].Values
-					.Where(x => !presentValues.Contains(x.Name))
-					.Select(x => x.ToCompletionItem("Sprite loader"));
+				return codeSymbols.AssetLoaders["Sprite"]
+					.Where(x => !presentValues.Contains(x.Key))
+					.Select(x => x.First().ToCompletionItem("Sprite loader"));
 
 			if (cursorTarget.TargetNode.Key == "VideoFormats")
-				return codeSymbols.AssetLoaders["Video"].Values
-					.Where(x => !presentValues.Contains(x.Name))
-					.Select(x => x.ToCompletionItem("Video loader"));
+				return codeSymbols.AssetLoaders["Video"]
+					.Where(x => !presentValues.Contains(x.Key))
+					.Select(x => x.First().ToCompletionItem("Video loader"));
 
 			// TODO: Other *Formats are not implemented yet:
 			//if (cursorTarget.TargetNode.Key == "TerrainFormat")

--- a/server/Oraide.LanguageServer/FileHandlingServices/ModFileHandlingService.Value.Definition.cs
+++ b/server/Oraide.LanguageServer/FileHandlingServices/ModFileHandlingService.Value.Definition.cs
@@ -22,17 +22,17 @@ namespace Oraide.LanguageServer.FileHandlingServices
 		IEnumerable<Location> HandleValueDefinitionAt0(CursorTarget cursorTarget)
 		{
 			// Asset loaders:
-			if (cursorTarget.TargetNode.Key == "PackageFormats" && codeSymbols.AssetLoaders["Package"].TryGetValue(cursorTarget.TargetString, out var packageLoader))
-				return new [] { packageLoader.Location.ToLspLocation(packageLoader.NameWithTypeSuffix.Length) };
+			if (cursorTarget.TargetNode.Key == "PackageFormats")
+				return codeSymbols.AssetLoaders["Package"][cursorTarget.TargetString].Select(x => x.Location.ToLspLocation(x.NameWithTypeSuffix.Length));
 
-			if (cursorTarget.TargetNode.Key == "SoundFormats" && codeSymbols.AssetLoaders["Sound"].TryGetValue(cursorTarget.TargetString, out var soundLoader))
-				return new [] { soundLoader.Location.ToLspLocation(soundLoader.NameWithTypeSuffix.Length) };
+			if (cursorTarget.TargetNode.Key == "SoundFormats")
+				return codeSymbols.AssetLoaders["Sound"][cursorTarget.TargetString].Select(x => x.Location.ToLspLocation(x.NameWithTypeSuffix.Length));
 
-			if (cursorTarget.TargetNode.Key == "SpriteFormats" && codeSymbols.AssetLoaders["Sprite"].TryGetValue(cursorTarget.TargetString, out var spriteLoader))
-				return new [] { spriteLoader.Location.ToLspLocation(spriteLoader.NameWithTypeSuffix.Length) };
+			if (cursorTarget.TargetNode.Key == "SpriteFormats")
+				return codeSymbols.AssetLoaders["Sprite"][cursorTarget.TargetString].Select(x => x.Location.ToLspLocation(x.NameWithTypeSuffix.Length));
 
-			if (cursorTarget.TargetNode.Key == "VideoFormats" && codeSymbols.AssetLoaders["Video"].TryGetValue(cursorTarget.TargetString, out var videoLoader))
-				return new [] { videoLoader.Location.ToLspLocation(videoLoader.NameWithTypeSuffix.Length) };
+			if (cursorTarget.TargetNode.Key == "VideoFormats")
+				return codeSymbols.AssetLoaders["Video"][cursorTarget.TargetString].Select(x => x.Location.ToLspLocation(x.NameWithTypeSuffix.Length));
 
 			// TODO: Other *Formats are not implemented yet:
 			//if (cursorTarget.TargetNode.Key == "TerrainFormat")

--- a/server/Oraide.LanguageServer/FileHandlingServices/ModFileHandlingService.Value.Hover.cs
+++ b/server/Oraide.LanguageServer/FileHandlingServices/ModFileHandlingService.Value.Hover.cs
@@ -1,4 +1,5 @@
-﻿using LspTypes;
+﻿using System.Linq;
+using LspTypes;
 using Oraide.Core.Entities.MiniYaml;
 using Oraide.LanguageServer.Abstractions.FileHandlingServices;
 
@@ -20,17 +21,33 @@ namespace Oraide.LanguageServer.FileHandlingServices
 		Hover HandleValueHoverAt0(CursorTarget cursorTarget)
 		{
 			// Asset loaders:
-			if (cursorTarget.TargetNode.Key == "PackageFormats" && codeSymbols.AssetLoaders["Package"].TryGetValue(cursorTarget.TargetString, out var packageLoader))
-				return IHoverService.HoverFromHoverInfo($"Package loader **{packageLoader.NameWithTypeSuffix}**.", range);
+			if (cursorTarget.TargetNode.Key == "PackageFormats")
+			{
+				var loaders = codeSymbols.AssetLoaders["Package"][cursorTarget.TargetString];
+				if (loaders.Any())
+					return IHoverService.HoverFromHoverInfo($"Package loader **{loaders.First().NameWithTypeSuffix}**.", range);
+			}
 
-			if (cursorTarget.TargetNode.Key == "SoundFormats" && codeSymbols.AssetLoaders["Sound"].TryGetValue(cursorTarget.TargetString, out var soundLoader))
-				return IHoverService.HoverFromHoverInfo($"Sound loader **{soundLoader.NameWithTypeSuffix}**.", range);
+			if (cursorTarget.TargetNode.Key == "SoundFormats")
+			{
+				var loaders = codeSymbols.AssetLoaders["Sound"][cursorTarget.TargetString];
+				if (loaders.Any())
+					return IHoverService.HoverFromHoverInfo($"Sound loader **{loaders.First().NameWithTypeSuffix}**.", range);
+			}
 
-			if (cursorTarget.TargetNode.Key == "SpriteFormats" && codeSymbols.AssetLoaders["Sprite"].TryGetValue(cursorTarget.TargetString, out var spriteLoader))
-				return IHoverService.HoverFromHoverInfo($"Sprite loader **{spriteLoader.NameWithTypeSuffix}**.", range);
+			if (cursorTarget.TargetNode.Key == "SpriteFormats")
+			{
+				var loaders = codeSymbols.AssetLoaders["Sprite"][cursorTarget.TargetString];
+				if (loaders.Any())
+					return IHoverService.HoverFromHoverInfo($"Sprite loader **{loaders.First().NameWithTypeSuffix}**.", range);
+			}
 
-			if (cursorTarget.TargetNode.Key == "VideoFormats" && codeSymbols.AssetLoaders["Video"].TryGetValue(cursorTarget.TargetString, out var videoLoader))
-				return IHoverService.HoverFromHoverInfo($"Video loader **{videoLoader.NameWithTypeSuffix}**.", range);
+			if (cursorTarget.TargetNode.Key == "VideoFormats")
+			{
+				var loaders = codeSymbols.AssetLoaders["Video"][cursorTarget.TargetString];
+				if (loaders.Any())
+					return IHoverService.HoverFromHoverInfo($"Video loader **{loaders.First().NameWithTypeSuffix}**.", range);
+			}
 
 			// TODO: Other *Formats are not implemented yet:
 			//if (cursorTarget.TargetNode.Key == "TerrainFormat")


### PR DESCRIPTION
Because CombinedArms had a copy of R8Loader with the exact same name and the dictionary would crash. They shouldn't do that, but we can't expect people to follow the rules so better be safe.